### PR TITLE
change the columns used for actionnetwork

### DIFF
--- a/ListManagement/Utils.py
+++ b/ListManagement/Utils.py
@@ -15,7 +15,7 @@ class Constants:
         FIRST_NAME = "first_name"
         MIDDLE_NAME = "middle_name"
         LAST_NAME = "last_name"
-        STANDING_COL = "membership_status"
+        STANDING_COL = "actionkit_is_member_in_good_standing"
         EMAIL_COL = "email"
 
         # One of the following two will exist
@@ -45,7 +45,7 @@ class Constants:
 
     class MEMBERSHIP_STATUS:
         LAPSED = "lapsed"
-        GOOD_STANDING = "member in good standing"
+        GOOD_STANDING = "true"
         MEMBER = "member"
 
 

--- a/ListManagement/validateVote.py
+++ b/ListManagement/validateVote.py
@@ -186,6 +186,7 @@ def main(args):
             if vote.vote == Constants.VOTE_TYPES.ABSTAIN:
                 numAbstain += 1
         if not vote.found:
+            print(f"did not find member for email {vote.email}")
             vote.status = "Not in list"
         outputRows.append(vote.toRow())
 


### PR DESCRIPTION
It appears that the `membership_status` field in actionnetwork is deprecated. Some tool out there will update our membership list in ActionNetwork, and will set a bunch of fields that are prefixed with `actionkit_`. We should use those columns instead to determine membership status.